### PR TITLE
Gdpr improvement

### DIFF
--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -37,5 +37,11 @@
     _paq.push(["setDocumentTitle", title]);
     _paq.push(["trackPageView"]);
     _paq.push(['enableLinkTracking']);
+    if (settings.do_not_track) {
+        _paq.push(["setDoNotTrack", true]);
+    }
+    if (settings.tracking_cookies) {
+        _paq.push(["disableCookies"]);
+    }
   });
 </script>

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -33,15 +33,17 @@
       _paq.push(["setDomains", allDomains]);
     }
 
+    if (settings.do_not_track) {
+        _paq.push(["setDoNotTrack", true]);
+    }
+
+    if (settings.tracking_cookies) {
+        _paq.push(["disableCookies"]);
+    }
+
     _paq.push(["setCustomUrl", url]);
     _paq.push(["setDocumentTitle", title]);
     _paq.push(["trackPageView"]);
     _paq.push(['enableLinkTracking']);
-    if (settings.do_not_track) {
-        _paq.push(["setDoNotTrack", true]);
-    }
-    if (settings.tracking_cookies) {
-        _paq.push(["disableCookies"]);
-    }
   });
 </script>

--- a/settings.yml
+++ b/settings.yml
@@ -17,3 +17,11 @@ subdomain_tracking:
   type: bool
   default: false
   description: Track visitors across main domain & subdomains, assuming discourse is on a subdomain.
+do_not_track:
+  type: bool
+  default: true
+  description: So tracking requests will not be sent if visitors do not wish to be tracked
+tracking_cookies:
+  type: bool
+  default: true
+  description: Disables all first party cookies. Existing Matomo cookies for this website will be deleted on the next pageview.


### PR DESCRIPTION
I've added 2 settings, which I think should be enabled by default to make this idiot-proof for GDPR.

More info:
* https://matomo.org/blog/2021/10/matomo-exempt-from-tracking-consent-in-france/
* https://matomo.org/faq/general/configure-privacy-settings-in-matomo/
* https://developer.matomo.org/api-reference/tracking-javascript#configuration-of-tracking-cookies

Let me know what you think. Also, please be extra critical, this is the first time I'm working with Discourse plugins. Some more info on the background of this request: https://meta.discourse.org/t/script-to-enable-matomo-analytics-on-discourse/33090/61?u=aqual1te